### PR TITLE
Fix incorrect link to Patrik Mooney's 'Wings of Exec'

### DIFF
--- a/stage_1.md
+++ b/stage_1.md
@@ -54,7 +54,7 @@ arguments; this replaces the running process (the child copy of the
 shell) with the new command.  So now we have both our shell and the
 command running, and the shell knows the process ID of the command.
 (See Patrick Mooney's talk [On Wings of
-exec(2)](https://systemswe.love/archive/minneapolis-2017/patrick-mooney)
+exec(2)](https://www.youtube.com/watch?v=xh9E3BvwqBs)
 for deeper details of what happens after we `execve`.)
 
 The parent now waits for the child to complete; we do this with


### PR DESCRIPTION
The given link for wings of exec currently redirects to https://oxide.computer/ which no longer hosts anything by Patrik Mooney (if it does, it is not obvious). 

Instead link to wings of exec on youtube.